### PR TITLE
Don't error if g:vim_json_warnings is toggled

### DIFF
--- a/syntax/jsonc.vim
+++ b/syntax/jsonc.vim
@@ -20,7 +20,9 @@ endif
 runtime syntax/json.vim
 
 " Remove syntax group for comments treated as errors
-syn clear jsonCommentError
+if !exists("g:vim_json_warnings") || g:vim_json_warnings
+  syn clear jsonCommentError
+endif
 
 " Define syntax matching comments and their contents
 syn keyword jsonCommentTodo  FIXME NOTE TBD TODO XXX


### PR DESCRIPTION
You can disable vim_json_warnings via this varaible and it'll prevent
jsonComentError from being defined and thus this line will cause runtime
errors. Guard it here.