### PR TITLE
Fix #7 - Error opening a .jsonc file

### DIFF
--- a/ftplugin/jsonc.vim
+++ b/ftplugin/jsonc.vim
@@ -6,14 +6,8 @@ else
   let b:did_ftplugin_jsonc = 1
 endif
 
-" A list of commands that undo buffer local changes made below.
-let s:undo_ftplugin = []
-
-" Set comment (formatting) related options. {{{1
+" Set comment (formatting) related options.
 setlocal commentstring=//%s comments=sO:*\ -,mO:*\ \ ,exO:*/,s1:/*,mb:*,ex:*/,://
-call add(s:undo_ftplugin, 'commentstring< comments<')
 
 " Let Vim know how to disable the plug-in.
-call map(s:undo_ftplugin, "'execute ' . string(v:val)")
-let b:undo_ftplugin = join(s:undo_ftplugin, ' | ')
-unlet s:undo_ftplugin
+let b:undo_ftplugin = 'setlocal commentstring< comments<'


### PR DESCRIPTION
The vaue of `b:undo_ftplugin` is setted to `execute 'commentstring< comments<'`.  When undoing the filetype, vim will complain `E492: Not an editor command: commentstring< comments<`. 

In this case,  simply set to `setlocal commentstring< comments<` should be enough.

